### PR TITLE
Implements the question with multiple countries

### DIFF
--- a/components/holiday.jsx
+++ b/components/holiday.jsx
@@ -1,24 +1,20 @@
 import PropTypes from 'prop-types';
 import moment from 'moment';
 
-const displayWithCountry = (country, name) => (
-  <p>
-    {country.emoji} {country.name}: {name}
-  </p>
-);
+const formatHoliday = (holiday) => {
+  let message = '';
+  if (holiday.showCountry) {
+    message += `${holiday.country.emoji} ${holiday.country.name}: `;
+  }
+  message += `${holiday.name} on ${moment(holiday.date).format(
+    'dddd, MMMM Do'
+  )} (${moment(holiday.date).fromNow()})`;
 
-const displayWithDate = (date, name) => (
-  <p>
-    {name} on {moment(date).format('dddd, MMMM Do')} ({moment(date).fromNow()})
-  </p>
-);
+  return message;
+};
 
 export default function Holiday(props) {
-  if (props.date) {
-    return displayWithDate(props.date, props.name);
-  }
-
-  return displayWithCountry(props.country, props.name);
+  return <p>{formatHoliday(props)}</p>;
 }
 
 Holiday.propTypes = {

--- a/components/holidayInTheWorld.jsx
+++ b/components/holidayInTheWorld.jsx
@@ -1,0 +1,17 @@
+import PropTypes from 'prop-types';
+
+export default function Holiday({ country, name }) {
+  return (
+    <p>
+      {country.emoji} {country.name}: {name}
+    </p>
+  );
+}
+
+Holiday.propTypes = {
+  name: PropTypes.string.isRequired,
+  country: PropTypes.shape({
+    name: PropTypes.string,
+    emoji: PropTypes.string,
+  }),
+};

--- a/components/holidays.jsx
+++ b/components/holidays.jsx
@@ -4,11 +4,16 @@ import Holiday from './holiday';
 import React, { useEffect } from 'react';
 
 const displayResults = (answer_title, holidays) => {
+  const countries = new Set();
+  for (let holiday of holidays) {
+    countries.add(holiday.country.name);
+  }
+  const showCountry = countries.size > 1;
   return (
     <div>
       <h2>{answer_title}</h2>
       {holidays.map((element, index) => (
-        <Holiday key={index} {...element} />
+        <Holiday showCountry={showCountry} key={index} {...element} />
       ))}
     </div>
   );

--- a/components/holidays.jsx
+++ b/components/holidays.jsx
@@ -29,6 +29,9 @@ const displayError = (error) => {
     case 'unknown_country':
       errorMessage = 'The country was not recognized';
       break;
+    case 'unknown_question':
+      errorMessage = 'This questions is not supported or understood';
+      break;
   }
 
   return errorMessage;

--- a/components/holidaysInTheWorld.jsx
+++ b/components/holidaysInTheWorld.jsx
@@ -1,6 +1,6 @@
 import useSwr from 'swr';
 import fetchAPI from '../utils/apiClient';
-import Holiday from './holiday';
+import HolidayInTheWorld from './holidayInTheWorld';
 import styles from './holidaysInTheWorld.module.css';
 import moment from 'moment';
 import React from 'react';
@@ -19,13 +19,13 @@ export default function HolidaysInTheWorld({ holidaysWorldwide }) {
         <div>
           <h2>{moment(data[0].date).format('dddd, MMMM Do')}</h2>
           {data[0].holidays.map((element, index) => (
-            <Holiday key={index} {...element} />
+            <HolidayInTheWorld key={index} {...element} />
           ))}
         </div>
         <div>
           <h2>{moment(data[1].date).format('dddd, MMMM Do')}</h2>
           {data[1].holidays.map((element, index) => (
-            <Holiday key={index} {...element} />
+            <HolidayInTheWorld key={index} {...element} />
           ))}
         </div>
       </div>

--- a/lib/holidays.js
+++ b/lib/holidays.js
@@ -9,6 +9,8 @@ export async function getHolidays(countryCode, startDate, endDate, count) {
 
   const results = [];
 
+  const { name, emoji } = getCountry(countryCode);
+
   if (Array.isArray(response)) {
     const holidays = response.filter((entry) => entry.global == true);
 
@@ -17,7 +19,13 @@ export async function getHolidays(countryCode, startDate, endDate, count) {
         if (endDate && moment(holidays[i].date).isAfter(endDate)) {
           break;
         }
-        results.push(holidays[i]);
+
+        results.push({
+          date: holidays[i].date,
+          name: holidays[i].name,
+          country: { name, emoji },
+        });
+
         if (count && --count == 0) {
           break;
         }

--- a/lib/holidays.test.js
+++ b/lib/holidays.test.js
@@ -111,7 +111,14 @@ describe('getHolidays', () => {
       'https://date.nager.at/api/v2/nextpublicholidays/AR'
     );
     expect(holidays).toHaveLength(1);
-    expect(holidays[0]).toEqual(mockedHolidays['AR-1']);
+    expect(holidays[0]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'General José de San Martín Memorial Day',
+      date: '2020-08-17',
+    });
   });
 
   test('gets the next holidays for a given country in a date interval', async () => {
@@ -130,8 +137,22 @@ describe('getHolidays', () => {
       'https://date.nager.at/api/v2/nextpublicholidays/AR'
     );
     expect(holidays).toHaveLength(2);
-    expect(holidays[0]).toEqual(mockedHolidays['AR-2']);
-    expect(holidays[1]).toEqual(mockedHolidays['AR-3']);
+    expect(holidays[0]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2020-10-12',
+    });
+    expect(holidays[1]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'National Sovereignty Day',
+      date: '2020-11-20',
+    });
   });
 });
 

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -2,6 +2,16 @@ import { getHolidays } from './holidays';
 import { getCountryAlpha2, getCountry } from './countries';
 import moment from 'moment';
 
+const sortHolidays = (a, b) => {
+  if (moment(a.date).isBefore(b.date)) {
+    return -1;
+  }
+  if (moment(a.date).isAfter(b.date)) {
+    return 1;
+  }
+  return 0;
+};
+
 /**
  * This function parses the output from the Wit.ai structured result
  * QUESTIONS ALREADY IMPLEMENTED?
@@ -22,12 +32,6 @@ export default async function questionResolver(intents, entities) {
 
   if (!entities['country:country']) {
     return { status: 'missing_country' };
-  }
-
-  const country = getCountryAlpha2(entities['country:country'][0].value);
-
-  if (!country) {
-    return { status: 'unknown_country' };
   }
 
   // TODO: extract to a function
@@ -68,15 +72,33 @@ export default async function questionResolver(intents, entities) {
       return { status: 'unknown_question' };
   }
 
-  const holidays = await getHolidays(country, startDate, endDate, count);
-  const { name: countryName } = getCountry(country);
+  const holidays = [];
+  const countryNames = [];
+
+  for (const countryEntry of entities['country:country']) {
+    const country = getCountryAlpha2(countryEntry.value);
+    if (country) {
+      countryNames.push(getCountry(country).name);
+      holidays.push(...(await getHolidays(country, startDate, endDate, count)));
+    }
+  }
+
+  // if we couldn't recognize a country we return this error
+  if (countryNames.length == 0) {
+    return { status: 'unknown_country' };
+  }
+
+  // sort only if we have more than one country in the results
+  if (countryNames.length > 1) {
+    holidays.sort(sortHolidays);
+  }
 
   if (holidays.length == 0) {
     answer_title = 'There are no holidays';
   } else if (holidays.length == 1) {
-    answer_title = `The holiday in ${countryName} is`;
+    answer_title = `The holiday in ${holidays[0].country.name} is`;
   } else {
-    answer_title = `The holidays in ${countryName} are`;
+    answer_title = `The holidays in ${countryNames.join(', ')} are`;
   }
 
   return { status: 'success', answer_title, holidays };

--- a/lib/questions.test.js
+++ b/lib/questions.test.js
@@ -131,9 +131,47 @@ const holidays_ukraine_september = {
   traits: {},
 };
 
+const next_holidays_argentina_usa = {
+  text: 'what are the next holidays in argentina and usa?',
+  intents: [
+    { id: '2826295110810186', name: 'list_holidays', confidence: 0.9973 },
+  ],
+  entities: {
+    'country:country': [
+      {
+        id: '693128311268219',
+        name: 'country',
+        role: 'country',
+        start: 30,
+        end: 39,
+        body: 'argentina',
+        confidence: 0.9962,
+        entities: [],
+        value: 'argentina',
+        type: 'value',
+      },
+      {
+        id: '693128311268219',
+        name: 'country',
+        role: 'country',
+        start: 44,
+        end: 47,
+        body: 'usa',
+        confidence: 0.9817,
+        entities: [],
+        value: 'USA',
+        type: 'value',
+      },
+    ],
+  },
+  traits: {},
+};
+
 describe('questionResolver', () => {
   test('gets the next holiday for a given country', async () => {
-    const holidays = [{ date: '2020-08-17', name: 'a holiday' }];
+    const holidays = [
+      { date: '2020-08-17', name: 'a holiday', country: { name: 'Argentina' } },
+    ];
     const today = '2020-08-05';
 
     getHolidays.mockResolvedValue(holidays);
@@ -154,8 +192,16 @@ describe('questionResolver', () => {
 
   test('gets the holidays for a given country in the next two weeks and returns more than one', async () => {
     const holidays = [
-      { date: '2020-08-17', name: 'a holiday' },
-      { date: '2020-08-20', name: 'a second holiday' },
+      {
+        date: '2020-08-17',
+        name: 'a holiday',
+        country: { name: 'United States' },
+      },
+      {
+        date: '2020-08-20',
+        name: 'a second holiday',
+        country: { name: 'United States' },
+      },
     ];
     const startDate = jest.fn();
     const endDate = jest.fn();
@@ -184,7 +230,13 @@ describe('questionResolver', () => {
   });
 
   test('gets the holidays for a given country in the next two weeks and returns just one', async () => {
-    const holidays = [{ date: '2020-08-17', name: 'a holiday' }];
+    const holidays = [
+      {
+        date: '2020-08-17',
+        name: 'a holiday',
+        country: { name: 'United States' },
+      },
+    ];
     const startDate = jest.fn();
     const endDate = jest.fn();
 
@@ -241,8 +293,12 @@ describe('questionResolver', () => {
 
   test('gets the holidays for a given country for a given month', async () => {
     const holidays = [
-      { date: '2020-08-17', name: 'a holiday' },
-      { date: '2020-08-20', name: 'a second holiday' },
+      { date: '2020-08-17', name: 'a holiday', country: { name: 'Ukraine' } },
+      {
+        date: '2020-08-20',
+        name: 'a second holiday',
+        country: { name: 'Ukraine' },
+      },
     ];
     const startDate = jest.fn();
     const endDate = jest.fn();
@@ -268,6 +324,89 @@ describe('questionResolver', () => {
       status: 'success',
       answer_title: 'The holidays in Ukraine are',
       holidays,
+    });
+  });
+
+  test('gets the holidays for several countries and returns a list sorted by date', async () => {
+    // TODO: check how to mock moment to test for this array being sorted
+    const holidays_us = [
+      {
+        date: '2020-11-17',
+        name: 'a holiday in us',
+        country: { name: 'United States' },
+      },
+      {
+        date: '2020-12-20',
+        name: 'a second holiday in us',
+        country: { name: 'United States' },
+      },
+    ];
+    const holidays_ar = [
+      {
+        date: '2020-09-02',
+        name: 'a holiday in ar',
+        country: { name: 'Argentina' },
+      },
+      {
+        date: '2020-10-01',
+        name: 'a second holiday in ar',
+        country: { name: 'Argentina' },
+      },
+    ];
+
+    getHolidays
+      .mockResolvedValueOnce(holidays_ar)
+      .mockResolvedValueOnce(holidays_us);
+
+    moment.mockImplementation(
+      jest.fn(() => ({
+        isAfter: () => true,
+        isBefore: () => false,
+      }))
+    );
+
+    const response = await questionResolver(
+      next_holidays_argentina_usa.intents,
+      next_holidays_argentina_usa.entities
+    );
+
+    expect(getHolidays).toHaveBeenCalledWith(
+      'AR',
+      expect.anything(),
+      undefined,
+      undefined
+    );
+    expect(getHolidays).toHaveBeenCalledWith(
+      'US',
+      expect.anything(),
+      undefined,
+      undefined
+    );
+    expect(response).toEqual({
+      status: 'success',
+      answer_title: 'The holidays in Argentina, United States are',
+      holidays: [
+        {
+          date: '2020-09-02',
+          name: 'a holiday in ar',
+          country: { name: 'Argentina' },
+        },
+        {
+          date: '2020-10-01',
+          name: 'a second holiday in ar',
+          country: { name: 'Argentina' },
+        },
+        {
+          date: '2020-11-17',
+          name: 'a holiday in us',
+          country: { name: 'United States' },
+        },
+        {
+          date: '2020-12-20',
+          name: 'a second holiday in us',
+          country: { name: 'United States' },
+        },
+      ],
     });
   });
 });


### PR DESCRIPTION
Pending: refactor holidays API and component to show country and emoji when the answer contains holidays from multiple countries.

Refactor API to return a collection of countries, and holidays per country. Then the render component can decide if showing country names or not (only show if more than one country in the result, otherwise the title contains the country name).