### PR TITLE
Implements Calendarific

### DIFF
--- a/lib/holidays.js
+++ b/lib/holidays.js
@@ -2,27 +2,60 @@ import moment from 'moment';
 import fetchAPI from '../utils/apiClient';
 import { getCountry } from './countries';
 
-export async function getHolidays(countryCode, startDate, endDate, count) {
-  const url = `https://date.nager.at/api/v2/nextpublicholidays/${countryCode}`;
+async function fetchHolidaysFromNager(countryCode, year) {
+  const url = `https://date.nager.at/api/v2/publicholidays/${year}/${countryCode}`;
 
   const response = await fetchAPI(url);
 
+  return response
+    .filter((entry) => entry.global == true)
+    .map((h) => ({ name: h.name, date: h.date }));
+}
+
+async function fetchHolidays(countryCode, year) {
+  const url = `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=${countryCode}&year=${year}&type=national`;
+
+  try {
+    const result = await fetchAPI(url);
+
+    return result.response.holidays.map((h) => ({
+      name: h.name,
+      date: h.date.iso,
+    }));
+  } catch (e) {
+    return fetchHolidaysFromNager(countryCode, year);
+  }
+}
+
+export async function getHolidays(countryCode, startDate, endDate, count) {
   const results = [];
 
   const { name, emoji } = getCountry(countryCode);
 
-  if (Array.isArray(response)) {
-    const holidays = response.filter((entry) => entry.global == true);
+  let holidays;
+  let year = moment(startDate).year();
 
-    for (let i = 0; i < holidays.length; i++) {
-      if (moment(holidays[i].date).isSameOrAfter(startDate, 'day')) {
-        if (endDate && moment(holidays[i].date).isAfter(endDate, 'day')) {
+  // fetch from date.nager.at, only if the answer is 404 (no data for that country) use calendarific as backup
+  // or fetch from calendarific, if response is free tier limit, fall back to date.nager.at?
+  holidays = await fetchHolidays(countryCode, year);
+
+  if (endDate) {
+    let endYear = moment(endDate).year();
+    if (endYear > year) {
+      holidays.push(...(await fetchHolidays(countryCode, endYear)));
+    }
+  }
+
+  do {
+    for (let holiday of holidays) {
+      if (moment(holiday.date).isSameOrAfter(startDate, 'day')) {
+        if (endDate && moment(holiday.date).isAfter(endDate, 'day')) {
           break;
         }
 
         results.push({
-          date: holidays[i].date,
-          name: holidays[i].name,
+          date: holiday.date,
+          name: holiday.name,
           country: { name, emoji },
         });
 
@@ -31,7 +64,12 @@ export async function getHolidays(countryCode, startDate, endDate, count) {
         }
       }
     }
-  }
+
+    // if I still need holidays and there was no end date in the request then I go to the next year to fullfil the count
+    if (count && !endDate) {
+      holidays = await fetchHolidays(countryCode, year + 1);
+    }
+  } while (count);
 
   return results;
 }

--- a/lib/holidays.js
+++ b/lib/holidays.js
@@ -27,7 +27,7 @@ async function fetchHolidays(countryCode, year) {
   }
 }
 
-export async function getHolidays(countryCode, startDate, endDate, count) {
+export async function getHolidays({ countryCode, startDate, endDate, count }) {
   const results = [];
 
   const { name, emoji } = getCountry(countryCode);

--- a/lib/holidays.test.js
+++ b/lib/holidays.test.js
@@ -96,7 +96,11 @@ describe('getHolidays', () => {
     });
 
     const today = moment('2020-10-01');
-    const holidays = await getHolidays('AR', today, undefined, 2);
+    const holidays = await getHolidays({
+      countryCode: 'AR',
+      startDate: today,
+      count: 2,
+    });
 
     expect(fetchAPI).toHaveBeenCalledWith(
       `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
@@ -134,7 +138,11 @@ describe('getHolidays', () => {
 
     const startDate = moment('2020-10-01');
     const endDate = moment('2020-11-01');
-    const holidays = await getHolidays('AR', startDate, endDate);
+    const holidays = await getHolidays({
+      countryCode: 'AR',
+      startDate,
+      endDate,
+    });
 
     expect(fetchAPI).toHaveBeenCalledWith(
       `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
@@ -173,7 +181,11 @@ describe('getHolidays', () => {
 
     const startDate = moment('2020-10-01');
     const endDate = moment('2021-12-01');
-    const holidays = await getHolidays('AR', startDate, endDate);
+    const holidays = await getHolidays({
+      countryCode: 'AR',
+      startDate,
+      endDate,
+    });
 
     expect(fetchAPI).toHaveBeenCalledWith(
       `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
@@ -237,8 +249,12 @@ describe('getHolidays', () => {
         },
       });
 
-    const today = moment('2020-10-01');
-    const holidays = await getHolidays('AR', today, undefined, 3);
+    const startDate = moment('2020-10-01');
+    const holidays = await getHolidays({
+      countryCode: 'AR',
+      startDate,
+      count: 3,
+    });
 
     expect(fetchAPI).toHaveBeenCalledWith(
       `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
@@ -282,8 +298,12 @@ describe('getHolidays', () => {
       .mockRejectedValueOnce(new Error('Fetch API was not ok'))
       .mockResolvedValueOnce(mockedResponse);
 
-    const today = moment('2020-10-01');
-    const holidays = await getHolidays('AR', today, undefined, 2);
+    const startDate = moment('2020-10-01');
+    const holidays = await getHolidays({
+      countryCode: 'AR',
+      startDate,
+      count: 2,
+    });
 
     expect(fetchAPI).toHaveBeenCalledWith(
       `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`

--- a/lib/holidays.test.js
+++ b/lib/holidays.test.js
@@ -6,92 +6,79 @@ jest.mock('../utils/apiClient');
 
 const mockedHolidays = {
   'AR-1': {
-    date: '2020-08-17',
-    localName: 'Paso a la Inmortalidad del General José de San Martín',
+    date: {
+      iso: '2020-08-17',
+    },
     name: 'General José de San Martín Memorial Day',
-    countryCode: 'AR',
-    fixed: false,
-    global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
   },
   'AR-2': {
-    date: '2020-10-12',
-    localName: 'Día del Respeto a la Diversidad Cultural',
+    date: {
+      iso: '2020-10-12',
+    },
     name: 'Day of Respect for Cultural Diversity',
-    countryCode: 'AR',
-    fixed: false,
-    global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
   },
   'AR-3': {
-    date: '2020-11-20',
-    localName: 'Día de la Soberanía Nacional',
+    date: {
+      iso: '2020-11-20',
+    },
     name: 'National Sovereignty Day',
-    countryCode: 'AR',
-    fixed: true,
+  },
+  'AR-4': {
+    date: {
+      iso: '2021-01-12',
+    },
+    name: 'Day of Respect for Cultural Diversity',
+  },
+  'AR-5': {
+    date: {
+      iso: '2021-02-20',
+    },
+    name: 'National Sovereignty Day',
+  },
+  'AR-nager-1': {
+    date: '2020-08-17',
+    name: 'General José de San Martín Memorial Day',
     global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
+  },
+  'AR-nager-2': {
+    date: '2020-10-12',
+    name: 'Day of Respect for Cultural Diversity',
+    global: true,
+  },
+  'AR-nager-3': {
+    date: '2020-11-20',
+    name: 'National Sovereignty Day',
+    global: true,
   },
   'US-1': {
-    date: '2020-09-07',
-    localName: 'Labor Day',
+    date: {
+      iso: '2020-09-07',
+    },
     name: 'Labour Day',
-    countryCode: 'US',
-    fixed: false,
-    global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
   },
   'BO-1': {
     date: '2020-08-02',
-    localName: 'Día de la Revolución Agraria',
     name: 'Agrarian Reform Day',
-    countryCode: 'BO',
-    fixed: true,
     global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
+    countryCode: 'BO',
   },
   'AU-1': {
     date: '2020-08-03',
-    localName: 'Picnic Day',
     name: 'Picnic Day',
-    countryCode: 'AU',
-    fixed: false,
     global: false,
-    counties: ['AUS-NT'],
-    launchYear: null,
-    type: 'Public',
+    countryCode: 'AU',
   },
   'GD-1': {
     date: '2020-08-03',
-    localName: 'Emancipation Day',
     name: 'Emancipation Day',
-    countryCode: 'GD',
-    fixed: false,
     global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
+    countryCode: 'GD',
   },
   'SV-1': {
     date: '2020-08-04',
-    localName: 'Fiestas de agosto',
     name: 'August Festivals',
-    countryCode: 'SV',
-    fixed: true,
     global: true,
-    counties: null,
-    launchYear: null,
-    type: 'Public',
+    countryCode: 'SV',
   },
 };
 
@@ -102,13 +89,17 @@ describe('getHolidays', () => {
       mockedHolidays['AR-2'],
       mockedHolidays['AR-3'],
     ];
-    fetchAPI.mockResolvedValue(mockedResponse);
+    fetchAPI.mockResolvedValue({
+      response: {
+        holidays: mockedResponse,
+      },
+    });
 
-    const today = moment('2020-08-01');
+    const today = moment('2020-10-01');
     const holidays = await getHolidays('AR', today, undefined, 2);
 
     expect(fetchAPI).toHaveBeenCalledWith(
-      'https://date.nager.at/api/v2/nextpublicholidays/AR'
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
     );
     expect(holidays).toHaveLength(2);
     expect(holidays[0]).toEqual({
@@ -116,16 +107,16 @@ describe('getHolidays', () => {
         emoji: '🇦🇷',
         name: 'Argentina',
       },
-      name: 'General José de San Martín Memorial Day',
-      date: '2020-08-17',
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2020-10-12',
     });
     expect(holidays[1]).toEqual({
       country: {
         emoji: '🇦🇷',
         name: 'Argentina',
       },
-      name: 'Day of Respect for Cultural Diversity',
-      date: '2020-10-12',
+      name: 'National Sovereignty Day',
+      date: '2020-11-20',
     });
   });
 
@@ -135,14 +126,170 @@ describe('getHolidays', () => {
       mockedHolidays['AR-2'],
       mockedHolidays['AR-3'],
     ];
-    fetchAPI.mockResolvedValue(mockedResponse);
+    fetchAPI.mockResolvedValue({
+      response: {
+        holidays: mockedResponse,
+      },
+    });
 
     const startDate = moment('2020-10-01');
-    const endDate = moment('2020-12-01');
+    const endDate = moment('2020-11-01');
     const holidays = await getHolidays('AR', startDate, endDate);
 
     expect(fetchAPI).toHaveBeenCalledWith(
-      'https://date.nager.at/api/v2/nextpublicholidays/AR'
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
+    );
+    expect(holidays).toHaveLength(1);
+    expect(holidays[0]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2020-10-12',
+    });
+  });
+  test('gets holidays asking for the next year if end date is in the next year', async () => {
+    const mockedResponseFirstYear = [
+      mockedHolidays['AR-1'],
+      mockedHolidays['AR-2'],
+      mockedHolidays['AR-3'],
+    ];
+    const mockedResponseSecondYear = [
+      mockedHolidays['AR-4'],
+      mockedHolidays['AR-5'],
+    ];
+    fetchAPI
+      .mockResolvedValueOnce({
+        response: {
+          holidays: mockedResponseFirstYear,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: {
+          holidays: mockedResponseSecondYear,
+        },
+      });
+
+    const startDate = moment('2020-10-01');
+    const endDate = moment('2021-12-01');
+    const holidays = await getHolidays('AR', startDate, endDate);
+
+    expect(fetchAPI).toHaveBeenCalledWith(
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
+    );
+    expect(fetchAPI).toHaveBeenCalledWith(
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2021&type=national`
+    );
+    expect(holidays).toHaveLength(4);
+    expect(holidays[0]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2020-10-12',
+    });
+    expect(holidays[1]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'National Sovereignty Day',
+      date: '2020-11-20',
+    });
+    expect(holidays[2]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2021-01-12',
+    });
+    expect(holidays[3]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'National Sovereignty Day',
+      date: '2021-02-20',
+    });
+  });
+  test('gets the next 10 holidays for a given country and fetches the next year', async () => {
+    const mockedResponseFirstYear = [
+      mockedHolidays['AR-1'],
+      mockedHolidays['AR-2'],
+      mockedHolidays['AR-3'],
+    ];
+    const mockedResponseSecondYear = [
+      mockedHolidays['AR-4'],
+      mockedHolidays['AR-5'],
+    ];
+    fetchAPI
+      .mockResolvedValueOnce({
+        response: {
+          holidays: mockedResponseFirstYear,
+        },
+      })
+      .mockResolvedValueOnce({
+        response: {
+          holidays: mockedResponseSecondYear,
+        },
+      });
+
+    const today = moment('2020-10-01');
+    const holidays = await getHolidays('AR', today, undefined, 3);
+
+    expect(fetchAPI).toHaveBeenCalledWith(
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
+    );
+    expect(fetchAPI).toHaveBeenCalledWith(
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2021&type=national`
+    );
+    expect(holidays).toHaveLength(3);
+    expect(holidays[0]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2020-10-12',
+    });
+    expect(holidays[1]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'National Sovereignty Day',
+      date: '2020-11-20',
+    });
+    expect(holidays[2]).toEqual({
+      country: {
+        emoji: '🇦🇷',
+        name: 'Argentina',
+      },
+      name: 'Day of Respect for Cultural Diversity',
+      date: '2021-01-12',
+    });
+  });
+  test('gets the next holidays for a given country and falls back to second provider due to an error with the principal', async () => {
+    const mockedResponse = [
+      mockedHolidays['AR-nager-1'],
+      mockedHolidays['AR-nager-2'],
+      mockedHolidays['AR-nager-3'],
+    ];
+    fetchAPI
+      .mockRejectedValueOnce(new Error('Fetch API was not ok'))
+      .mockResolvedValueOnce(mockedResponse);
+
+    const today = moment('2020-10-01');
+    const holidays = await getHolidays('AR', today, undefined, 2);
+
+    expect(fetchAPI).toHaveBeenCalledWith(
+      `https://calendarific.com/api/v2/holidays?&api_key=${process.env.CALENDARIFIC_TOKEN}&country=AR&year=2020&type=national`
+    );
+    expect(fetchAPI).toHaveBeenCalledWith(
+      'https://date.nager.at/api/v2/publicholidays/2020/AR'
     );
     expect(holidays).toHaveLength(2);
     expect(holidays[0]).toEqual({

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -142,6 +142,8 @@ export default async function questionResolver(intents, entities) {
 
   const { intent, data } = getIntent(intents, entities);
 
+  const { count, searchTerm } = data;
+
   if (!intent) {
     return { status: 'unknown_question' };
   }
@@ -162,16 +164,16 @@ export default async function questionResolver(intents, entities) {
   let holidays = [];
   const countryNames = [];
 
-  for (const countryEntry of countries) {
-    countryNames.push(getCountry(countryEntry).name);
-    for (const dateEntry of dateRanges) {
+  for (const countryCode of countries) {
+    countryNames.push(getCountry(countryCode).name);
+    for (const { startDate, endDate } of dateRanges) {
       holidays.push(
-        ...(await getHolidays(
-          countryEntry,
-          dateEntry.startDate,
-          dateEntry.endDate,
-          data.count
-        ))
+        ...(await getHolidays({
+          countryCode,
+          startDate,
+          endDate,
+          count,
+        }))
       );
     }
   }
@@ -182,10 +184,10 @@ export default async function questionResolver(intents, entities) {
   }
 
   if (intent == 'search') {
-    if (!data.searchTerm) {
+    if (!searchTerm) {
       return { status: 'search_term_not_recognized' };
     }
-    holidays = filterBySearch(holidays, data.searchTerm);
+    holidays = filterBySearch(holidays, searchTerm);
   }
 
   let answer_title;

--- a/lib/questions.test.js
+++ b/lib/questions.test.js
@@ -310,17 +310,22 @@ describe('questionResolver', () => {
         country: { name: 'Argentina' },
       },
     ];
-    const today = '2020-08-05';
+    const startDate = '2020-08-05';
 
     getHolidays.mockResolvedValue(holidays);
-    moment.mockReturnValueOnce(today);
+    moment.mockReturnValueOnce(startDate);
 
     const response = await questionResolver(
       next_holiday_in_argentina.intents,
       next_holiday_in_argentina.entities
     );
     expect(moment).toHaveBeenCalled();
-    expect(getHolidays).toHaveBeenCalledWith('AR', today, undefined, 1);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'AR',
+      startDate,
+      endDate: undefined,
+      count: 1,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holiday in Argentina is',
@@ -354,7 +359,12 @@ describe('questionResolver', () => {
 
     expect(moment).toHaveBeenCalledWith('2020-08-10T00:00:00.000-07:00');
     expect(moment).toHaveBeenCalledWith('2020-08-24T00:00:00.000-07:00');
-    expect(getHolidays).toHaveBeenCalledWith('US', startDate, endDate, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'US',
+      startDate,
+      endDate,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holidays in United States are',
@@ -383,7 +393,12 @@ describe('questionResolver', () => {
 
     expect(moment).toHaveBeenCalledWith('2020-08-10T00:00:00.000-07:00');
     expect(moment).toHaveBeenCalledWith('2020-08-24T00:00:00.000-07:00');
-    expect(getHolidays).toHaveBeenCalledWith('US', startDate, endDate, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'US',
+      startDate,
+      endDate,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holiday in United States is',
@@ -406,7 +421,12 @@ describe('questionResolver', () => {
 
     expect(moment).toHaveBeenCalledWith('2020-08-10T00:00:00.000-07:00');
     expect(moment).toHaveBeenCalledWith('2020-08-24T00:00:00.000-07:00');
-    expect(getHolidays).toHaveBeenCalledWith('US', startDate, endDate, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'US',
+      startDate,
+      endDate,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'There are no holidays',
@@ -437,7 +457,12 @@ describe('questionResolver', () => {
     );
 
     expect(moment).toHaveBeenCalledWith('2020-09-01T00:00:00.000-07:00');
-    expect(getHolidays).toHaveBeenCalledWith('UA', startDate, endDate, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'UA',
+      startDate,
+      endDate,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holidays in Ukraine are',
@@ -488,18 +513,18 @@ describe('questionResolver', () => {
       next_holidays_argentina_usa.entities
     );
 
-    expect(getHolidays).toHaveBeenCalledWith(
-      'AR',
-      expect.anything(),
-      undefined,
-      null
-    );
-    expect(getHolidays).toHaveBeenCalledWith(
-      'US',
-      expect.anything(),
-      undefined,
-      null
-    );
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'AR',
+      startDate: expect.anything(),
+      endDate: undefined,
+      count: null,
+    });
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'US',
+      startDate: expect.anything(),
+      endDate: undefined,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holidays in Argentina, United States are',
@@ -535,17 +560,22 @@ describe('questionResolver', () => {
         country: { name: 'United States' },
       },
     ];
-    const today = '2020-08-05';
+    const startDate = '2020-08-05';
 
     getHolidays.mockResolvedValue(holidays);
-    moment.mockReturnValueOnce(today);
+    moment.mockReturnValueOnce(startDate);
 
     const response = await questionResolver(
       when_is_labour_day_in_usa.intents,
       when_is_labour_day_in_usa.entities
     );
     expect(moment).toHaveBeenCalled();
-    expect(getHolidays).toHaveBeenCalledWith('US', today, undefined, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'US',
+      startDate,
+      endDate: undefined,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holiday in United States is',
@@ -570,17 +600,22 @@ describe('questionResolver', () => {
         country: { name: 'United States' },
       },
     ];
-    const today = '2020-08-05';
+    const startDate = '2020-08-05';
 
     getHolidays.mockResolvedValue(holidays);
-    moment.mockReturnValueOnce(today);
+    moment.mockReturnValueOnce(startDate);
 
     const response = await questionResolver(
       when_is_carnival_in_argentina.intents,
       when_is_carnival_in_argentina.entities
     );
     expect(moment).toHaveBeenCalled();
-    expect(getHolidays).toHaveBeenCalledWith('AR', today, undefined, null);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'AR',
+      startDate,
+      endDate: undefined,
+      count: null,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holidays in Argentina are',
@@ -622,7 +657,12 @@ describe('questionResolver', () => {
     );
 
     expect(moment).toHaveBeenCalledWith();
-    expect(getHolidays).toHaveBeenCalledWith('AR', startDate, undefined, 2);
+    expect(getHolidays).toHaveBeenCalledWith({
+      countryCode: 'AR',
+      startDate,
+      endDate: undefined,
+      count: 2,
+    });
     expect(response).toEqual({
       status: 'success',
       answer_title: 'The holidays in Argentina are',

--- a/utils/apiClient.js
+++ b/utils/apiClient.js
@@ -3,6 +3,10 @@ export default async function fetchAPI(...args) {
 
   const res = await fetch(...args, { headers });
 
+  if (!res.ok) {
+    throw new Error('Fetch API was not ok');
+  }
+
   const json = await res.json();
 
   return json;

--- a/utils/apiClient.test.js
+++ b/utils/apiClient.test.js
@@ -1,0 +1,36 @@
+import fetchAPI from './apiClient';
+
+describe('fetchAPI', () => {
+  test('fetches ok', async () => {
+    const mockResult = jest.fn();
+    const args = jest.fn();
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(mockResult),
+      })
+    );
+
+    const result = await fetchAPI(args);
+
+    expect(global.fetch).toHaveBeenCalledWith(args, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(result).toBe(mockResult);
+  });
+  test('throws on error', async () => {
+    const args = jest.fn();
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: false,
+      })
+    );
+
+    await expect(fetchAPI(args)).rejects.toThrow();
+    expect(global.fetch).toHaveBeenCalledWith(args, {
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});


### PR DESCRIPTION
This provider has data for more countries.

Since I'm using the free tier which has a limit of 1000 requests/month if we reach the limit it defaults to date.nager.at (fewer countries).

Caveat is that the list of next worldwide holidays still comes from date.nager.at and there might be inconsistencies.